### PR TITLE
❗️Hotfix - Set babel-preset-env modules to false

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
   "presets": [
     [
       "env", {
-        "modules": false,
         "targets": {
           "browsers": [
             "> 5% in US",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,0 @@
-export * from './atob';
-export * from './btoa';
-//# sourceMappingURL=index.js.map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lighthouse/abab",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "WHATWG spec-compliant implementations of window.atob and window.btoa.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
If using main package.json property must out ES5 code for downstream projects.